### PR TITLE
Update viho_demo.c

### DIFF
--- a/viho_demo.c
+++ b/viho_demo.c
@@ -240,8 +240,8 @@ static void warp_homography_generic(float *y, int yw, int yh, double H[3][3],
 	{
 		double p[2] = {i, j};
 		apply_homography(p, H, p);
-		p[0] += 1.0;
-		p[1] += 1.0;
+		//p[0] += 1.0;
+		//p[1] += 1.0;
 		//p[0] = p[0] * w / (w - 1.0) - 0.5;
 		//p[1] = p[1] * h / (h - 1.0) - 0.5;
 		for (int l = 0; l < pd; l++)


### PR DESCRIPTION
En enlevant les lignes 243-244
p[0] += 1.0;
p[1] += 1.0;
il n'y a plus de décalage entre les interpolations bicubiques/bilinéaires et la vérité terrain (https://github.com/hugomoe/ground_truth). Il reste le décalage avec la méthode par décomposition.
